### PR TITLE
[リスト] fix:リスト画面でヘッダーに戻る矢印が表示されている

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -11,9 +11,9 @@ const Index = ():JSX.Element => {
         {
           // 匿名ログイン状態によってパラメーターの値を変更
           if(user.isAnonymous){
-            router.push({ pathname: '/ImpulseBuyStop/list', params: { anonymous: 'true' }})
+            router.replace({ pathname: '/ImpulseBuyStop/list', params: { anonymous: 'true' }})
           }else{
-            router.push({ pathname: '/ImpulseBuyStop/list', params: { anonymous: 'false' }})
+            router.replace({ pathname: '/ImpulseBuyStop/list', params: { anonymous: 'false' }})
           }
         }
       }


### PR DESCRIPTION
#14 
index.tsxのrouter.push → router.replaceに変更

対応後、リスト画面で、戻る矢印が表示されない事を確認

![image](https://github.com/user-attachments/assets/038357ae-f6c1-4248-b7e2-efee4e0777b9)
