### PR TITLE
[詳細表示] fix:詳細表示でデータが取得できない

### DIFF
--- a/src/app/ImpulseBuyStop/detail.tsx
+++ b/src/app/ImpulseBuyStop/detail.tsx
@@ -51,12 +51,17 @@ const Detail = (): JSX.Element => {
       const data = itemDoc.data()
       if (data) {
         const buyItem: BuyItem = {
-          id: itemDoc.id,
           bodyText: data.bodyText,
           updatedAt: data.updatedAt,
           priority: data.priority
         }
         setItems(buyItem)
+      }else{
+        Alert.alert('詳細表示データの取得に失敗しました','もう一度開いて発生する場合は運営に問い合わせお願いいたします。',[
+          {
+            text:'OK'
+          }
+        ])
       }
     })
 

--- a/src/app/ImpulseBuyStop/list.tsx
+++ b/src/app/ImpulseBuyStop/list.tsx
@@ -129,7 +129,7 @@ const List = ():JSX.Element => {
           // 出力用配列に追加
           // 優先度をgetpriorityName関数で変換(code → 優先度名)
           const buyItem: OutPutBuyItem = {
-            id: data.id,
+            id: doc.id, // idはコレクション要素として不可していないので、ドキュメントオブジェクトから取得する
             bodyText: data.bodyText,
             updatedAt: data.updatedAt,
             priority: getpriorityName(priorityType,data.priority)


### PR DESCRIPTION
取得失敗時のアラート表示追加
リストでid設定時、コレクション → ドキュメントidに変更