### PR TITLE
[アカウント]add: 新規登録時、確認メール送信処理追加

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -11,17 +11,13 @@ import { auth } from '../config'
 const Index = ():JSX.Element => {
   useEffect(()=>{
     // ログイン状態をチェックしてユーザーが取得できたらリスト画面に書き換え、取得できない場合はログイン画面に遷移
-    onAuthStateChanged(auth, (user) =>{
-      if ( user !== null ) {
-        {
-          // 匿名ログイン状態によってパラメーターの値を変更
-          if(user.isAnonymous){
-            router.replace({ pathname: '/ImpulseBuyStop/list', params: { anonymous: 'true' }})
-          }else{
-            router.replace({ pathname: '/ImpulseBuyStop/list', params: { anonymous: 'false' }})
-          }
-        }
-      }
+    onAuthStateChanged(auth, (user) => {
+      if (!user || !user.emailVerified) return
+
+      router.replace({
+        pathname: '/ImpulseBuyStop/list',
+        params: { anonymous: user.isAnonymous ? 'true' : 'false' }
+      })
     })
 
   },[])


### PR DESCRIPTION
indexのログイン状態判定にuser.emailVerifiedを追加
sign_up.tsxで確認メール未確認の場合、再送信処理を追加
log_in.tsxのログイン状態判定にuser.emailVerifiedを追加

issusse https://github.com/iwa-ma/ImpulseBuyStopApp/issues/77 の内容基に実施